### PR TITLE
docs(readme): add Community Showcase section (QiZishi's collection site, from #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,14 @@ Full contribution guide: [**CONTRIBUTING.md**](CONTRIBUTING.md) ([English](CONTR
   <img src="assets/wechat_group.jpg" alt="WeChat Group QR Code (shared with ARIS main repo)" width="300">
 </p>
 
+### 🔭 Community Showcase
+
+Community-built projects derived from this collection (MIT license — attribution-preserving reuse welcome):
+
+- **[大模型秋招教程 (ARIS-in-AI-Offer & Hello-Agents)](https://qizishi.github.io/Autumn-Recruitment-Tutorials-for-LLM/)** by [@QiZishi](https://github.com/QiZishi) — an online reading index that merges all 23 Chinese tutorials here with [Datawhale Hello-Agents](https://github.com/datawhalechina/hello-agents)' LLM interview Q&A, organized as clickable tutorial cards ([repo](https://github.com/QiZishi/Autumn-Recruitment-Tutorials-for-LLM) · from [#3](https://github.com/wanshuiyin/ARIS-in-AI-Offer/issues/3)).
+
+Built something on top of these tutorials? Open an issue and we'll list it here.
+
 ---
 
 ## 🌟 What is ARIS — A Quick Pitch

--- a/README_CN.md
+++ b/README_CN.md
@@ -293,6 +293,14 @@ aris-homepage render --persona theory-minimal
   <img src="assets/wechat_group.jpg" alt="WeChat 群二维码（与 ARIS 主仓共享）" width="300">
 </p>
 
+### 🔭 社区衍生
+
+社区基于这套教程做的二次创作（本仓库 MIT license，欢迎保留署名的转载与整合）：
+
+- **[大模型秋招教程 (ARIS-in-AI-Offer & Hello-Agents)](https://qizishi.github.io/Autumn-Recruitment-Tutorials-for-LLM/)** by [@QiZishi](https://github.com/QiZishi) —— 把这里的 23 篇中文教程与 [Datawhale Hello-Agents](https://github.com/datawhalechina/hello-agents) 的大模型面试问答整合成可跳转的教程卡片索引站，方便在线随时阅读（[仓库](https://github.com/QiZishi/Autumn-Recruitment-Tutorials-for-LLM) · 来自 [#3](https://github.com/wanshuiyin/ARIS-in-AI-Offer/issues/3)）。
+
+基于这套教程做了新东西？开个 issue，我们把它列在这里。
+
 ---
 
 ## 🌟 ARIS 是什么 — 顺便安利一下


### PR DESCRIPTION
## What

Adds a **🔭 Community Showcase / 社区衍生** subsection under `## 💬 Community` in both READMEs (bilingual parity), listing the first community-built derivative:

- [大模型秋招教程 (ARIS-in-AI-Offer & Hello-Agents)](https://qizishi.github.io/Autumn-Recruitment-Tutorials-for-LLM/) by @QiZishi — merges our 23 Chinese tutorials with Datawhale Hello-Agents' interview Q&A into an online card-index reading site. From #3.

Plus a standing invitation: build something on top → open an issue → get listed.

## Why

#3 sat unanswered for a week; the site is live, properly attributed (ARIS-in-AI-Offer + wanshuiyin + Hello-Agents all credited), and MIT-compliant. Featuring it gives contributors visibility and encourages more community reuse.

## Verification

- `verify_reviews.py --mode strict`: 47 OK · 0 WARN · 0 FAIL · 3 EXEMPT → PASS
- All external links verified live (QiZishi site + repo, datawhalechina/hello-agents)
- EN/CN sections mirror each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)