### PR TITLE
docs(readme): drop redundant top ARIS-Homepage banner (de-dup + remove stale NEW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ A curated, **bilingual** (中文 + English) collection of ML / LLM / multimodal 
 
 Each cheat sheet is a long-form Chinese tutorial with: formula derivations · from-scratch PyTorch code · 25 high-frequency interview questions (L1 essentials · L2 advanced · L3 top-tier lab).
 
-> 🔥 **NEW** · 🌐 **Also in this repo** — [**ARIS-Homepage**](#-aris-homepage--fact-checked-academic-homepage-from-cv): turn your **CV + selected GitHub repos** into a fact-checked academic homepage with single-file HTML output. v1.1 adds `--from-repos owner/repo,...` — `gh` CLI snapshots stars / releases / READMEs and merges repo timelines into your homepage. [**🔥 Live demo at wanshuiyin.github.io →**](https://wanshuiyin.github.io/)
-
 <p align="center">
   <img src="assets/preview_strip.jpg" alt="ARIS-in-AI-Offer preview — Foundations + Interview Q&A + From-Scratch Code, three columns from a representative cheat sheet" width="100%">
 </p>

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,8 +22,6 @@
 
 每篇都是一份长文 + 公式 + 从零开始的 PyTorch 代码 + 25 高频面试题（L1 必会 · L2 进阶 · L3 顶级 lab）。
 
-> 🔥 **新 feature** · 🌐 **本仓库另一个 feature** —— [**ARIS-Homepage**](#-aris-homepage--fact-checked-学术主页生成器)：用 **CV + 你选的 GitHub repos** 一键生成 fact-checked 学术主页，单文件 HTML 输出。v1.1 新增 `--from-repos owner/repo,...` —— `gh` CLI 抓 stars / releases / READMEs，把 repo 时间线 merge 进主页。[**🔥 Live demo 在 wanshuiyin.github.io →**](https://wanshuiyin.github.io/)
-
 <p align="center">
   <img src="assets/preview_strip.jpg" alt="ARIS-in-AI-Offer 预览 — 基础知识 + 面试题 + 实际代码，截自一篇代表性 cheat sheet" width="100%">
 </p>


### PR DESCRIPTION
## What

Removes the top "🌐 Also in this repo — ARIS-Homepage …" banner (with its stale `🔥 NEW` badge) from both READMEs.

## Why

It duplicated the ARIS-Homepage **preview strip + caption** immediately below it (and the dedicated ARIS-Homepage section + two What's New entries). ARIS-Homepage shipped 2026-05-23, so the `NEW` badge was stale. No information lost — the homepage is still featured by its preview image, caption, full section, and What's New.

Bilingual parity preserved (removed from README.md and README_CN.md identically). README-only, 4 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)