### PR TITLE
docs(homepage-generator): make the ARIS-Homepage docs match what the code does

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ $EDITOR profile.yml             # tweak editorial choices
 python ../tools/aris_homepage.py render --persona theory-minimal
 ```
 
-> 🪟 **On Windows?** `aris-homepage` is not an installed command — invoke the script explicitly as `python .\tools\aris_homepage.py ...`. Full walkthrough incl. Python/poppler/SSL pitfalls: [`WINDOWS_en.md`](skills/homepage-generator/WINDOWS_en.md) ([中文](skills/homepage-generator/WINDOWS.md)).
+> 🪟 **On Windows?** Use `\` in the paths above, and mind the Windows-only traps — the `python3` alias stub, silent `.py` file association, non-ASCII `pdftotext` paths, SSL certificates. Full walkthrough: [`WINDOWS_en.md`](skills/homepage-generator/WINDOWS_en.md) ([中文](skills/homepage-generator/WINDOWS.md)).
 
 Output: `index.html` + `audit-report.md`. Drop the HTML on GitHub Pages, S3, university `~user/public_html/`, or attach to email — no build server. **Minimum runtime is just Python + a calling LLM agent**; Codex MCP optional for adversarial cross-model review; Gemini multimodal optional for visual critique.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Phone on the subway, iPad at a café, laptop in the library — same HTML link o
 - **2026-05-28** — ![POLISH](https://img.shields.io/badge/POLISH-blue?style=flat-square) ⚡ **`render-html` P0 polish + all 23 tutorials regenerated** — academic template gained 7 interactive features: print degradation fix (PDF no longer loses `<details>` content), TOC sidebar scrollspy (current section auto-highlights as you scroll), figure lightbox (native `<dialog>` with focus trap + Esc), long-code auto-collapse (`<pre>` ≥30 lines wrapped in `<details class="code-card">`, per-block override via ` ```python {collapsed}` / `{open}` fence flags), paper citation popover (new `[[key]]` MD syntax + `--papers <papers.json>` sidecar), eyebrow cleanup (marketing uppercase → body-serif gray), `--blog-mode` infrastructure (opt-in `aris-blog` body class). XSS-hardened script injection via `json_for_script()` (escapes `</script>` break-out). All 23 bilingual tutorial pairs (= 46 HTMLs) regenerated to pick up the new template shell — source MDs untouched. Codex GPT-5.5 xhigh 4-round review (design × 2 → code × 1 → spot-check × 1). Try it: scroll [`attention_tutorial.html`](docs/tutorials/attention_tutorial.html) and watch the TOC sidebar follow ([b79c57d](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/b79c57d), [8793f40](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/8793f40)).
 - **2026-05-26** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🐍 **5 runnable PyTorch tutorial scripts** — first runnable-code contribution in [`docs/tutorials/code/`](docs/tutorials/code/): [`mha.py`](docs/tutorials/code/mha.py) (MHA + causal mask) · [`axial_attention.py`](docs/tutorials/code/axial_attention.py) (H/W axial + complexity table) · [`flow_matching.py`](docs/tutorials/code/flow_matching.py) (Rectified Flow on 2D moons) · [`mmdit_block.py`](docs/tutorials/code/mmdit_block.py) (double-stream MMDiT block) · [`toy_mmdit_t2i_pipeline.py`](docs/tutorials/code/toy_mmdit_t2i_pipeline.py) (end-to-end T2I skeleton). Pure PyTorch, CPU-runnable in seconds, every script ships with built-in `assert` sanity checks (shape parity, numerical agreement with `nn.MultiheadAttention` where applicable). Pairs with [`attention_tutorial.md`](docs/tutorials/attention_tutorial.md) / [`flow_matching_tutorial.md`](docs/tutorials/flow_matching_tutorial.md) / [`image_generation_systems_tutorial.md`](docs/tutorials/image_generation_systems_tutorial.md) ([f63f468](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/f63f468)).
 - **2026-05-24** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🐙 **ARIS-Homepage v1.1: `--from-repos`** — snapshot user-selected `owner/repo` list via `gh` CLI; LLM agent merges repo timelines into homepage News + `featured_projects[].github`. Private repos skipped by default. Closes [#2](https://github.com/wanshuiyin/ARIS-in-AI-Offer/issues/2) by [@Yafei-Liu99](https://github.com/Yafei-Liu99) ([cdcf9a2](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/cdcf9a2)).
-- **2026-05-23** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🌐 **ARIS-Homepage v1 shipped** — CV → fact-checked academic homepage (DBLP / arXiv audit blocks wrong venue / year / author). Single-file HTML; Codex / Gemini reviews optional. Live demo: [wanshuiyin.github.io](https://wanshuiyin.github.io/). Skill: [`skills/homepage-generator/SKILL.md`](skills/homepage-generator/SKILL.md) ([b818c1d](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/b818c1d)).
+- **2026-05-23** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🌐 **ARIS-Homepage v1 shipped** — CV → fact-checked academic homepage (DBLP audit blocks wrong venue / year). Single-file HTML; Codex / Gemini reviews optional. Live demo: [wanshuiyin.github.io](https://wanshuiyin.github.io/). Skill: [`skills/homepage-generator/SKILL.md`](skills/homepage-generator/SKILL.md) ([b818c1d](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/b818c1d)).
 - **2026-05-22** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🦾 **Featured community contribution: 具身智能高频面试题库** by [@WinstonJQ](https://github.com/WinstonJQ) — 413 questions across 8 卷 (VLA / 模仿学习 / RL / 世界模型 / 工程落地 / 腿足控制 / 3D 感知 / 系统设计). Hosted externally; linked from the new "🦾 Embodied AI" category in the Tutorial Index ([b1ebb6f](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/b1ebb6f)).
 - **2026-05** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 📚 **4 new bilingual cheat sheets**: KL Divergence in RLHF (k1/k2/k3 · placement gradient bias), LLM On-Policy Distillation (MiniLLM / GKD / Qwen3 / Tinker), Diffusion Post-Training (DDPO / DPOK / DRaFT / AlignProp / Diffusion-DPO / Flow-GRPO), Diffusion / Flow Distillation (CM / iCT / sCM / CTM / LCM / DMD/DMD2 / ADD/LADD). Total now: **23 first-party cheat sheets**.
 - **2026-05** — ![DOCS](https://img.shields.io/badge/DOCS-blue?style=flat-square) 📖 **README restructure** — preview-strip banner, ARIS credentials at top (badges + 10K-star foundation paragraph), shared WeChat community QR with the [main ARIS repo](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep).
@@ -210,19 +210,21 @@ Cross-model adversarial review (executor ≠ reviewer family) is ARIS's core inv
 
 > **The only personal-site generator that fact-checks your CV before publishing.**
 
-A new skill in this repo: `/homepage-generator` turns your CV (`.docx` / `.pdf` / `.txt`) into a polished single-file academic homepage. Cross-model factual audit runs against DBLP / arXiv — wrong venue / year / author / fabricated awards block ship until corrected or explicitly overridden.
+A new skill in this repo: `/homepage-generator` turns your CV (`.docx` / `.pdf` / `.txt`) into a polished single-file academic homepage. A DBLP audit runs on every render unless you pass `--no-audit` — a wrong venue or year, or a Best Paper / Spotlight / Oral / Outstanding badge asserted without a link to the paper, blocks the render until corrected or explicitly overridden. (It does not check author lists.)
 
 **Live demo**: [wanshuiyin.github.io](https://wanshuiyin.github.io/) — generated by this skill from a CV + the maintainer's previous manual page as editorial reference. Preview strip is near the top of this README.
 
 ### Quick start
 
+There is no `aris-homepage` executable — this repo ships no installer, so call the script directly. The path is relative to where you are standing, which changes at the `cd`:
+
 ```bash
-aris-homepage init --from-cv ./cv.pdf --out ./site
+python tools/aris_homepage.py init --from-cv ./cv.pdf --out ./site
 cd ./site
 # Calling agent fills .aris-homepage/extraction.json per EXTRACTION_HANDOFF.md
-aris-homepage finalize
+python ../tools/aris_homepage.py finalize
 $EDITOR profile.yml             # tweak editorial choices
-aris-homepage render --persona theory-minimal
+python ../tools/aris_homepage.py render --persona theory-minimal
 ```
 
 > 🪟 **On Windows?** `aris-homepage` is not an installed command — invoke the script explicitly as `python .\tools\aris_homepage.py ...`. Full walkthrough incl. Python/poppler/SSL pitfalls: [`WINDOWS_en.md`](skills/homepage-generator/WINDOWS_en.md) ([中文](skills/homepage-generator/WINDOWS.md)).
@@ -270,9 +272,9 @@ Output: `index.html` + `audit-report.md`. Drop the HTML on GitHub Pages, S3, uni
               ▼               ▼               ▼
         ┌──────────┐    ┌──────────┐    ┌──────────────┐
         │ Layer-1  │    │ Layer-2  │    │ Layer-2      │
-        │ DBLP /   │    │ Codex MCP│    │ Gemini       │
-        │ arXiv    │    │ adv-rev  │    │ visual       │
-        │ fact-chk │    │ (opt.)   │    │ critique     │
+        │ DBLP     │    │ Codex MCP│    │ Gemini       │
+        │ fact-chk │    │ adv-rev  │    │ visual       │
+        │          │    │ (opt.)   │    │ critique     │
         │ (always) │    │          │    │ (opt.)       │
         └─────┬────┘    └──────────┘    └──────────────┘
               │
@@ -284,13 +286,13 @@ Output: `index.html` + `audit-report.md`. Drop the HTML on GitHub Pages, S3, uni
         └──────────────┘
 
    Typical flow (7 steps, ~5 minutes):
-     1. aris-homepage init --from-cv ./cv.pdf --out ./site
+     1. python tools/aris_homepage.py init --from-cv ./cv.pdf --out ./site
      2. (calling agent) read .aris-homepage/EXTRACTION_HANDOFF.md
         → fill .aris-homepage/extraction.json
-     3. aris-homepage finalize
+     3. cd ./site && python ../tools/aris_homepage.py finalize
      4. $EDITOR profile.yml publications.bib bio.md news.md
-     5. aris-homepage check --strict        # fact-check only
-     6. aris-homepage render --persona theory-minimal
+     5. python ../tools/aris_homepage.py check --strict   # fact-check only
+     6. python ../tools/aris_homepage.py render --persona theory-minimal
      7. inspect audit-report.md; fix → re-render OR --override-all
 
    Minimum runtime: Python + a calling LLM agent.

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Output: `index.html` + `audit-report.md`. Drop the HTML on GitHub Pages, S3, uni
         │ DBLP     │    │ Codex MCP│    │ Gemini       │
         │ fact-chk │    │ adv-rev  │    │ visual       │
         │          │    │ (opt.)   │    │ critique     │
-        │ (always) │    │          │    │ (opt.)       │
+        │ (default)│    │          │    │ (opt.)       │
         └─────┬────┘    └──────────┘    └──────────────┘
               │
               ▼

--- a/README_CN.md
+++ b/README_CN.md
@@ -227,7 +227,7 @@ $EDITOR profile.yml             # 调整编辑选择
 python ../tools/aris_homepage.py render --persona theory-minimal
 ```
 
-> 🪟 **Windows 用户**：`aris-homepage` 不是一个已安装的命令，要显式写成 `python .\tools\aris_homepage.py ...`。零基础完整走一遍（Python / poppler / SSL 各种坑）见 [`WINDOWS.md`](skills/homepage-generator/WINDOWS.md)（[English](skills/homepage-generator/WINDOWS_en.md)）。
+> 🪟 **Windows 用户**：上面的路径分隔符换成 `\`，另外还有几个 Windows 独有的坑 —— `python3` 空壳别名、`.py` 文件关联静默、`pdftotext` 中文路径、SSL 证书库。零基础完整走一遍见 [`WINDOWS.md`](skills/homepage-generator/WINDOWS.md)（[English](skills/homepage-generator/WINDOWS_en.md)）。
 
 输出：`index.html` + `audit-report.md`。HTML 扔 GitHub Pages、S3、学校 `~user/public_html/`、邮箱附件都行——零 build server。**最小运行时只要 Python + 调用方 LLM agent**；Codex MCP 可选（增强 adversarial 跨模型 review），Gemini 可选（多模态视觉 critique）。
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -87,7 +87,7 @@
 - **2026-05-28** — ![POLISH](https://img.shields.io/badge/POLISH-blue?style=flat-square) ⚡ **`render-html` P0 polish + 23 个 tutorial 全量 regenerate** —— academic 模板加了 7 个交互特性：print degradation 修复（PDF 导出不再丢 `<details>` 内容）、TOC 侧栏 scrollspy（当前 section 跟随滚动高亮）、figure lightbox（原生 `<dialog>` + focus trap + Esc）、长代码自动折叠（`<pre>` ≥30 行包成 `<details class="code-card">`，可用 ` ```python {collapsed}` / `{open}` fence flag 单块 override）、论文引用 popover（新增 `[[key]]` MD 语法 + `--papers <papers.json>` sidecar）、eyebrow 风格清理（marketing 大写 → 正文衬线灰）、`--blog-mode` 基础设施（opt-in `aris-blog` body class）。XSS 加固：`json_for_script()` 把 `<` / `>` / `&` / U+2028 等 escape 成 `\\uXXXX`，paper title 含 `</script>` 不会 break out。23 对双语 tutorial（共 46 个 HTML）全量 regenerate 吃到新模板，源 MD 没动。Codex GPT-5.5 xhigh 4 轮审（设计 ×2 → 代码 ×1 → spot-check ×1）。试试：滚动 [`attention_tutorial.html`](docs/tutorials/attention_tutorial.html) 看左侧 TOC 跟随高亮（[b79c57d](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/b79c57d)、[8793f40](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/8793f40)）。
 - **2026-05-26** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🐍 **5 个可跑的 PyTorch 教学脚本** —— [`docs/tutorials/code/`](docs/tutorials/code/) 是仓库第一批 runnable-code 贡献：[`mha.py`](docs/tutorials/code/mha.py)（MHA + causal mask）、[`axial_attention.py`](docs/tutorials/code/axial_attention.py)（H/W axial + 复杂度表）、[`flow_matching.py`](docs/tutorials/code/flow_matching.py)（2D moons 上的 Rectified Flow）、[`mmdit_block.py`](docs/tutorials/code/mmdit_block.py)（双流 MMDiT block）、[`toy_mmdit_t2i_pipeline.py`](docs/tutorials/code/toy_mmdit_t2i_pipeline.py)（端到端 toy T2I pipeline）。纯 PyTorch，CPU 几秒到几十秒跑完，每个脚本自带 `assert` sanity check（shape 对齐、必要时跟 `nn.MultiheadAttention` 数值校准）。配合 [`attention_tutorial.md`](docs/tutorials/attention_tutorial.md) / [`flow_matching_tutorial.md`](docs/tutorials/flow_matching_tutorial.md) / [`image_generation_systems_tutorial.md`](docs/tutorials/image_generation_systems_tutorial.md) 阅读（[f63f468](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/f63f468)）。
 - **2026-05-24** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🐙 **ARIS-Homepage v1.1：`--from-repos`** — 用户选定 `owner/repo` 列表通过 `gh` CLI 抓快照，调用方 LLM agent 把 repo 时间线 merge 进主页 News + `featured_projects[].github`。默认拒绝 private repo。Closes [#2](https://github.com/wanshuiyin/ARIS-in-AI-Offer/issues/2) by [@Yafei-Liu99](https://github.com/Yafei-Liu99)（[cdcf9a2](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/cdcf9a2)）。
-- **2026-05-23** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🌐 **ARIS-Homepage v1 上线** — CV → fact-checked 学术主页（DBLP / arXiv 审 venue/年份/作者，错的硬阻断 ship）。单文件 HTML；Codex / Gemini review 可选。Live demo：[wanshuiyin.github.io](https://wanshuiyin.github.io/)。Skill：[`skills/homepage-generator/SKILL.md`](skills/homepage-generator/SKILL.md)（[b818c1d](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/b818c1d)）。
+- **2026-05-23** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🌐 **ARIS-Homepage v1 上线** — CV → fact-checked 学术主页（DBLP 审 venue/年份，错的硬阻断 ship）。单文件 HTML；Codex / Gemini review 可选。Live demo：[wanshuiyin.github.io](https://wanshuiyin.github.io/)。Skill：[`skills/homepage-generator/SKILL.md`](skills/homepage-generator/SKILL.md)（[b818c1d](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/b818c1d)）。
 - **2026-05-22** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 🦾 **社区贡献 feature：具身智能高频面试题库** by [@WinstonJQ](https://github.com/WinstonJQ) —— 413 题 8 卷（VLA / 模仿学习 / RL / 世界模型 / 工程落地 / 腿足控制 / 3D 感知 / 系统设计），外部托管，从 Tutorial Index 新增的 "🦾 Embodied AI" 分类里链接过去（[b1ebb6f](https://github.com/wanshuiyin/ARIS-in-AI-Offer/commit/b1ebb6f)）。
 - **2026-05** — ![NEW](https://img.shields.io/badge/NEW-red?style=flat-square) 📚 **4 篇新双语 cheat sheet**：KL Divergence in RLHF（k1/k2/k3 · placement gradient bias）、LLM On-Policy Distillation（MiniLLM / GKD / Qwen3 / Tinker）、Diffusion Post-Training（DDPO / DPOK / DRaFT / AlignProp / Diffusion-DPO / Flow-GRPO）、Diffusion / Flow Distillation（CM / iCT / sCM / CTM / LCM / DMD/DMD2 / ADD/LADD）。总数：**23 篇 first-party cheat sheet**。
 - **2026-05** — ![DOCS](https://img.shields.io/badge/DOCS-blue?style=flat-square) 📖 **README 重构** —— 预览图 banner、ARIS 战绩前置（badges + 10K-star credibility paragraph）、与 [ARIS 主仓](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)共享微信群二维码。
@@ -210,19 +210,21 @@
 
 > **唯一一个发布前 fact-check 你 CV 的个人主页生成器。**
 
-本仓库新增的 skill：`/homepage-generator` 把你的 CV（`.docx` / `.pdf` / `.txt`）变成一个 polished 单文件学术主页。跨模型 fact-check 对 DBLP / arXiv 审核——错 venue / 错年份 / 错作者 / 编造奖项都硬阻断 ship，除非你显式 override。
+本仓库新增的 skill：`/homepage-generator` 把你的 CV（`.docx` / `.pdf` / `.txt`）变成一个 polished 单文件学术主页。每次 render 都会跑一遍 DBLP 核对（除非加 `--no-audit`）——venue 或年份对不上、声称了 Best Paper / Spotlight / Oral / Outstanding 却没填指向论文的链接，都会硬阻断,除非你改对或显式 override。（不核对作者名单。）
 
 **Live demo**：[wanshuiyin.github.io](https://wanshuiyin.github.io/) —— 这就是用这个 skill 跑 CV + 维护者之前 manual 主页（作 editorial reference）生成的。预览 strip 在 README 顶部。
 
 ### 快速开始
 
+`aris-homepage` 不是一个可执行命令 —— 本仓库不提供任何安装器，直接调脚本。路径是相对当前目录的，`cd` 之后会变：
+
 ```bash
-aris-homepage init --from-cv ./cv.pdf --out ./site
+python tools/aris_homepage.py init --from-cv ./cv.pdf --out ./site
 cd ./site
 # 调用方 agent 读 .aris-homepage/EXTRACTION_HANDOFF.md，填 extraction.json
-aris-homepage finalize
+python ../tools/aris_homepage.py finalize
 $EDITOR profile.yml             # 调整编辑选择
-aris-homepage render --persona theory-minimal
+python ../tools/aris_homepage.py render --persona theory-minimal
 ```
 
 > 🪟 **Windows 用户**：`aris-homepage` 不是一个已安装的命令，要显式写成 `python .\tools\aris_homepage.py ...`。零基础完整走一遍（Python / poppler / SSL 各种坑）见 [`WINDOWS.md`](skills/homepage-generator/WINDOWS.md)（[English](skills/homepage-generator/WINDOWS_en.md)）。
@@ -270,9 +272,9 @@ aris-homepage render --persona theory-minimal
               ▼               ▼               ▼
         ┌──────────┐    ┌──────────┐    ┌──────────────┐
         │ Layer-1  │    │ Layer-2  │    │ Layer-2      │
-        │ DBLP /   │    │ Codex MCP│    │ Gemini       │
-        │ arXiv    │    │ 对抗 rev │    │ 视觉 critique│
-        │ 事实审   │    │（可选）  │    │（可选）      │
+        │ DBLP     │    │ Codex MCP│    │ Gemini       │
+        │ 事实审   │    │ 对抗 rev │    │ 视觉 critique│
+        │          │    │（可选）  │    │（可选）      │
         │（默认）  │    │          │    │              │
         └─────┬────┘    └──────────┘    └──────────────┘
               │
@@ -284,13 +286,13 @@ aris-homepage render --persona theory-minimal
         └──────────────┘
 
    典型流程（7 步，~5 分钟）：
-     1. aris-homepage init --from-cv ./cv.pdf --out ./site
+     1. python tools/aris_homepage.py init --from-cv ./cv.pdf --out ./site
      2.（调用方 agent）读 .aris-homepage/EXTRACTION_HANDOFF.md
         → 填 .aris-homepage/extraction.json
-     3. aris-homepage finalize
+     3. cd ./site && python ../tools/aris_homepage.py finalize
      4. $EDITOR profile.yml publications.bib bio.md news.md
-     5. aris-homepage check --strict        # 只做 fact-check
-     6. aris-homepage render --persona theory-minimal
+     5. python ../tools/aris_homepage.py check --strict   # 只做 fact-check
+     6. python ../tools/aris_homepage.py render --persona theory-minimal
      7. 看 audit-report.md；修了 → 重 render 或 --override-all
 
    最小运行时：Python + 调用方 LLM agent

--- a/README_CN.md
+++ b/README_CN.md
@@ -210,7 +210,7 @@
 
 > **唯一一个发布前 fact-check 你 CV 的个人主页生成器。**
 
-本仓库新增的 skill：`/homepage-generator` 把你的 CV（`.docx` / `.pdf` / `.txt`）变成一个 polished 单文件学术主页。每次 render 都会跑一遍 DBLP 核对（除非加 `--no-audit`）——venue 或年份对不上、声称了 Best Paper / Spotlight / Oral / Outstanding 却没填指向论文的链接，都会硬阻断,除非你改对或显式 override。（不核对作者名单。）
+本仓库新增的 skill：`/homepage-generator` 把你的 CV（`.docx` / `.pdf` / `.txt`）变成一个 polished 单文件学术主页。每次 render 都会跑一遍 DBLP 核对（除非加 `--no-audit`）——venue 或年份对不上、声称了 Best Paper / Spotlight / Oral / Outstanding 却没填指向论文的链接，都会硬阻断，除非你改对或显式 override。（不核对作者名单。）
 
 **Live demo**：[wanshuiyin.github.io](https://wanshuiyin.github.io/) —— 这就是用这个 skill 跑 CV + 维护者之前 manual 主页（作 editorial reference）生成的。预览 strip 在 README 顶部。
 

--- a/skills/homepage-generator/PROFILE_SCHEMA.md
+++ b/skills/homepage-generator/PROFILE_SCHEMA.md
@@ -146,7 +146,7 @@ featured_projects:
         url: "https://github.com/owner/repo/releases/tag/v1.0"
 ```
 
-> **Note on `github:` subobject** (v1.1): populated by `aris-homepage init --from-repos owner/repo,...`. Written to `.aris-homepage/github_repos.json` first; calling LLM agent then maps it into `featured_projects[*].github` during the extraction step. Renderer does NOT auto-fetch — what's in profile.yml is what gets rendered (provenance lives in `snapshot_at`).
+> **Note on `github:` subobject** (v1.1): populated by `python tools/aris_homepage.py init --from-repos owner/repo,...`. Written to `.aris-homepage/github_repos.json` first; calling LLM agent then maps it into `featured_projects[*].github` during the extraction step. Renderer does NOT auto-fetch — what's in profile.yml is what gets rendered (provenance lives in `snapshot_at`).
 
 **Visual treatment**: the logo image floats right; text content (stats / links / elevator / sub-projects / open_problems) wraps around it, then continues full-width below the image. Use for ONE flagship project; the renderer supports multiple but visual weight stacks.
 

--- a/skills/homepage-generator/SKILL.md
+++ b/skills/homepage-generator/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: homepage-generator
 description: "Generate a fact-checked academic personal homepage from a CV, optionally augmented by an existing manual homepage and an assets directory. Produces editable structured source files (profile.yml + publications.bib + bio.md + news.md) and a single-file HTML page. Uses Codex MCP for independent factual review against DBLP. Optionally uses Gemini multimodal for screenshot critique when available. Use when the user says '做个学术主页', '从CV生成主页', 'aris-homepage', 'generate academic homepage from CV', 'PhD homepage', 'GitHub Pages personal site', or wants a fact-checked academic site."
-argument-hint: init --from-cv <cv.docx|cv.pdf|cv.txt> [--from-repos owner/repo,...] [--include-private] [--manual-homepage <url>] [--assets-dir <path>] [--out <dir>] [--force|--merge] | finalize | render --persona theory-minimal [--out <html>] [--override-all] [--no-audit] [--offline] | check [--strict] | doctor
+argument-hint: init --from-cv <cv.docx|cv.pdf|cv.txt> [--from-repos owner/repo,...] [--include-private] [--out <dir>] [--force] | finalize | render --persona theory-minimal [--out <html>] [--override-all] [--no-audit] [--offline] | check [--strict] | doctor
 allowed-tools: Bash(*), Read, Write, Edit, WebFetch, mcp__codex__codex
 ---
 
 # /homepage-generator — fact-checked academic homepage from CV
 
 > **The only personal-site generator that fact-checks your CV before publishing.**
-> Cross-model adversarial review: the LLM that drafts your homepage never grades it — a fresh Codex thread audits your publication claims against DBLP before the HTML is signed off.
+> Cross-model adversarial review: the LLM that drafts your homepage never grades it. A deterministic Python pass checks your publication claims against DBLP on every render; an optional fresh Codex thread then reviews the prose and framing.
 
 ## When to use
 
@@ -68,7 +68,7 @@ The `init` CLI only handles the CV → text conversion. The other two inputs are
 
 ## Commands
 
-Paths below are written from the repo root. `finalize`, `render` and `check` act on the **site workspace**, so from inside it the script is one level up — `python ../tools/aris_homepage.py ...`.
+`init` and `doctor` run from anywhere; the paths below assume the repo root. `finalize`, `render` and `check` act on the **site workspace** — `cd` into it first, which is why the script is one level up in those lines.
 
 ```bash
 python tools/aris_homepage.py init --from-cv <file> [--from-repos owner/repo,...] [--include-private] [--out DIR] [--force|--merge]
@@ -80,19 +80,20 @@ python tools/aris_homepage.py init --from-cv <file> [--from-repos owner/repo,...
   # Step 2.  Emit .aris-homepage/EXTRACTION_HANDOFF.md describing what the calling
   #          LLM agent should write to .aris-homepage/extraction.json
   #          (handoff doc auto-includes guidance on github_repos.json if present).
-  # --force: backup *.bak-TIMESTAMP and overwrite; --merge: fill-only (v1.2)
-  # NOTE: --manual-homepage and --assets-dir flags coming in v1.2; for now,
-  #       the calling agent handles those sources via prompt context.
+  # --force: backup *.bak-TIMESTAMP and overwrite.
+  # --merge is parsed but not implemented — it exits with a clear message.
+  # NOTE: --manual-homepage / --assets-dir do not exist yet; for now the
+  #       calling agent handles those sources via prompt context.
 
-python tools/aris_homepage.py finalize [--out DIR]
+python ../tools/aris_homepage.py finalize        # or from elsewhere: --out DIR
   # Ingest .aris-homepage/extraction.json → profile.yml + publications.bib +
   # bio.md + news.md + EXTRACTION_REVIEW.md.
 
-python tools/aris_homepage.py render --persona theory-minimal [--out index.html] [--override-all] [--no-audit] [--offline]
+python ../tools/aris_homepage.py render --persona theory-minimal [--out index.html] [--override-all] [--no-audit] [--offline]
   # Run fact-check (unless --no-audit) and render. Hard-fail blocks ship unless
   # --override-all (loudly logged in audit-report.md).
 
-python tools/aris_homepage.py check [--strict]
+python ../tools/aris_homepage.py check [--strict]
   # Fact-check only; updates audit-report.md. --strict treats WARN as FAIL.
 
 python tools/aris_homepage.py doctor
@@ -129,7 +130,7 @@ Core schema groups (read `PROFILE_SCHEMA.md` for the exact field shapes):
 - **`selected_publications`**: flat list OR ordered topic groups (`[{group: "Topic Title", keys: [bibkey1, ...]}]`)
 - **`publications`**: `preamble` (intro sentence before first H3)
 - **`publications_meta.<bibkey>`**: `thumbnail`, `description` (blue blurb box), `awards` (list of badges), `co_first` (equal-contribution markers), `links` (arXiv / paper / code / slides / openreview / etc. — any key supported)
-- **`audit.overrides.<bibkey>`**: per-paper, per-field bypass with required `reason` and optional `expires: YYYY-MM-DD`
+- **`audit.overrides.<bibkey>`**: per-paper bypass — any non-empty, unexpired object skips that paper's DBLP checks. `reason` is recorded, not enforced; `expires: YYYY-MM-DD` becomes a hard failure once past
 - **`ship`**: `persona`, `accent_color`, `lang`, `awards_heading` (override "Awards" → custom string)
 
 ## Fact-check protocol
@@ -152,7 +153,7 @@ Runs automatically during every `render` (unless `--no-audit`). Three outcomes p
 
 Two distinct review layers; do not confuse them:
 
-**Layer 1 — automated factual audit (always runs)**
+**Layer 1 — automated factual audit (default; skipped only with `--no-audit`)**
 `render` and `check` run a deterministic Python pipeline that queries DBLP (with a 4-attempt backoff + local cache at `.aris-homepage/dblp-cache.json`). Nothing queries arXiv: a DBLP miss is a WARN either way, and an `eprint` / `archiveprefix` field already in your BibTeX only changes how that warning is labelled. No external LLM needed. This is the **floor** of fact-check, and it works with **zero** AI-runtime dependencies beyond Python + the calling shell.
 
 **Layer 2 — optional adversarial LLM review (recommended for high-stakes)**
@@ -242,7 +243,7 @@ The public demo at `wanshuiyin.github.io` is the **only exception** — it's an 
 ## Acceptance criteria (v1 done)
 
 1. `python tools/aris_homepage.py init --from-cv` produces editable scaffolding from any user's CV (single-file `.docx` or `.pdf`).
-2. `python tools/aris_homepage.py render --persona theory-minimal` produces a single HTML file ≤500KB (no images) or ≤2MB (with photo + thumbnails inline), or smaller still when images are referenced via remote URLs.
+2. `python ../tools/aris_homepage.py render --persona theory-minimal` (from the site workspace) produces a single HTML file ≤500KB (no images) or ≤2MB (with photo + thumbnails inline), or smaller still when images are referenced via remote URLs.
 3. Fact-check correctly hard-fails on a corrupted profile.yml (e.g., venue swap NeurIPS↔ICML) and passes when corrected.
 4. The HTML is publishable on GitHub Pages / Netlify / S3 / any static host without a build step.
 5. `python tools/aris_homepage.py doctor` accurately reports environment readiness.

--- a/skills/homepage-generator/SKILL.md
+++ b/skills/homepage-generator/SKILL.md
@@ -145,7 +145,7 @@ Runs automatically during every `render` (unless `--no-audit`). Three outcomes p
 
 **Override two-layer**:
 - Per-paper in profile.yml: `audit.overrides.<bibkey>` — any non-empty, unexpired override object skips the DBLP checks for that paper entirely (it is not enforced per-field). `reason:` is recorded in the report but not required; `expires:` is, once past, a hard failure
-- CLI emergency: `python tools/aris_homepage.py render --override-all` (every override loudly logged)
+- CLI emergency: `python ../tools/aris_homepage.py render --override-all` (every override loudly logged)
 
 **Honest scope of fact-check**: DBLP lookups cover only the papers listed in `selected_publications`; the award-badge sweep covers every entry in `publications_meta`. It catches venue/year mismatch and award badges asserted without a link. It does **not** check author lists at all, and it never compares the title DBLP returned — the title is only the search query. Does NOT verify: workshop papers without DBLP entries, industry tech reports, blog/talk content, OSS star counts, or arbitrary claims in the bio. Treat the audit as a **diagnostic floor**, not a guarantee.
 

--- a/skills/homepage-generator/SKILL.md
+++ b/skills/homepage-generator/SKILL.md
@@ -24,7 +24,7 @@ A real-world dogfood example: **https://wanshuiyin.github.io/** — homepage gen
 
 ## Quick start
 
-> This repo ships **no installer** — there is no `aris-homepage` executable on any platform. Every invocation is `python <path>/aris_homepage.py`, and the path is relative to wherever you are standing (note the `cd ./site` below).
+> This repo ships **no installer** — there is no `aris-homepage` executable on any platform. Every invocation is `python <path>/aris_homepage.py`, and the path is relative to wherever you are standing (note the `cd ./site` below). On Windows also read [`WINDOWS_en.md`](WINDOWS_en.md) / [`WINDOWS.md`](WINDOWS.md).
 
 ```bash
 # Step 1 — bootstrap workspace from CV
@@ -47,7 +47,7 @@ $EDITOR profile.yml publications.bib bio.md news.md EXTRACTION_REVIEW.md
 python ../tools/aris_homepage.py render --persona theory-minimal
 ```
 
-> **Windows note.** `aris-homepage` is not an installed command on any platform — this repo ships no installer, so every invocation is `python <path>\aris_homepage.py <subcommand>`. See [`WINDOWS_en.md`](WINDOWS_en.md) / [`WINDOWS.md`](WINDOWS.md) for the Windows-specific pitfalls (`python3` alias stub, `.py` file association, non-ASCII `pdftotext` paths, SSL certificate store).
+> **Windows note.** Beyond the invocation form above, Windows has its own traps: the `python3` alias stub, silent `.py` file association, non-ASCII `pdftotext` paths, and the SSL certificate store. [`WINDOWS_en.md`](WINDOWS_en.md) / [`WINDOWS.md`](WINDOWS.md) walk through all of them.
 
 ## Input model — three sources for the LLM agent
 

--- a/skills/homepage-generator/SKILL.md
+++ b/skills/homepage-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: homepage-generator
-description: "Generate a fact-checked academic personal homepage from a CV, optionally augmented by an existing manual homepage and an assets directory. Produces editable structured source files (profile.yml + publications.bib + bio.md + news.md) and a single-file HTML page. Uses Codex MCP for independent factual review against DBLP / arXiv. Optionally uses Gemini multimodal for screenshot critique when available. Use when the user says '做个学术主页', '从CV生成主页', 'aris-homepage', 'generate academic homepage from CV', 'PhD homepage', 'GitHub Pages personal site', or wants a fact-checked academic site."
+description: "Generate a fact-checked academic personal homepage from a CV, optionally augmented by an existing manual homepage and an assets directory. Produces editable structured source files (profile.yml + publications.bib + bio.md + news.md) and a single-file HTML page. Uses Codex MCP for independent factual review against DBLP. Optionally uses Gemini multimodal for screenshot critique when available. Use when the user says '做个学术主页', '从CV生成主页', 'aris-homepage', 'generate academic homepage from CV', 'PhD homepage', 'GitHub Pages personal site', or wants a fact-checked academic site."
 argument-hint: init --from-cv <cv.docx|cv.pdf|cv.txt> [--from-repos owner/repo,...] [--include-private] [--manual-homepage <url>] [--assets-dir <path>] [--out <dir>] [--force|--merge] | finalize | render --persona theory-minimal [--out <html>] [--override-all] [--no-audit] [--offline] | check [--strict] | doctor
 allowed-tools: Bash(*), Read, Write, Edit, WebFetch, mcp__codex__codex
 ---
@@ -8,7 +8,7 @@ allowed-tools: Bash(*), Read, Write, Edit, WebFetch, mcp__codex__codex
 # /homepage-generator — fact-checked academic homepage from CV
 
 > **The only personal-site generator that fact-checks your CV before publishing.**
-> Cross-model adversarial review: the LLM that drafts your homepage never grades it — a fresh Codex thread audits every claim against DBLP / arXiv before the HTML is signed off.
+> Cross-model adversarial review: the LLM that drafts your homepage never grades it — a fresh Codex thread audits your publication claims against DBLP before the HTML is signed off.
 
 ## When to use
 
@@ -24,9 +24,11 @@ A real-world dogfood example: **https://wanshuiyin.github.io/** — homepage gen
 
 ## Quick start
 
+> This repo ships **no installer** — there is no `aris-homepage` executable on any platform. Every invocation is `python <path>/aris_homepage.py`, and the path is relative to wherever you are standing (note the `cd ./site` below).
+
 ```bash
 # Step 1 — bootstrap workspace from CV
-aris-homepage init --from-cv ./cv.pdf --out ./site
+python tools/aris_homepage.py init --from-cv ./cv.pdf --out ./site
 cd ./site
 
 # Step 2 — calling LLM agent (Claude / your agent) reads .aris-homepage/EXTRACTION_HANDOFF.md,
@@ -35,13 +37,14 @@ cd ./site
 #          can use richer context (manual homepage URL, asset folder, your judgement).
 
 # Step 3 — persist the extracted JSON into editable source files
-aris-homepage finalize
+#          (we cd'd into ./site above, so the script is one level up now)
+python ../tools/aris_homepage.py finalize
 
 # Step 4 — review + tweak
 $EDITOR profile.yml publications.bib bio.md news.md EXTRACTION_REVIEW.md
 
 # Step 5 — render with fact-check (writes index.html + audit-report.md)
-aris-homepage render --persona theory-minimal
+python ../tools/aris_homepage.py render --persona theory-minimal
 ```
 
 > **Windows note.** `aris-homepage` is not an installed command on any platform — this repo ships no installer, so every invocation is `python <path>\aris_homepage.py <subcommand>`. See [`WINDOWS_en.md`](WINDOWS_en.md) / [`WINDOWS.md`](WINDOWS.md) for the Windows-specific pitfalls (`python3` alias stub, `.py` file association, non-ASCII `pdftotext` paths, SSL certificate store).
@@ -65,8 +68,10 @@ The `init` CLI only handles the CV → text conversion. The other two inputs are
 
 ## Commands
 
+Paths below are written from the repo root. `finalize`, `render` and `check` act on the **site workspace**, so from inside it the script is one level up — `python ../tools/aris_homepage.py ...`.
+
 ```bash
-aris-homepage init --from-cv <file> [--from-repos owner/repo,...] [--include-private] [--out DIR] [--force|--merge]
+python tools/aris_homepage.py init --from-cv <file> [--from-repos owner/repo,...] [--include-private] [--out DIR] [--force|--merge]
   # Step 1. Extract CV to plain text (via textutil / python-docx / pdftotext).
   # Step 1b. (v1.1) If --from-repos given, snapshot each repo via `gh` CLI
   #          (GraphQL metadata + REST README, truncated 20KB) →
@@ -79,18 +84,18 @@ aris-homepage init --from-cv <file> [--from-repos owner/repo,...] [--include-pri
   # NOTE: --manual-homepage and --assets-dir flags coming in v1.2; for now,
   #       the calling agent handles those sources via prompt context.
 
-aris-homepage finalize [--out DIR]
+python tools/aris_homepage.py finalize [--out DIR]
   # Ingest .aris-homepage/extraction.json → profile.yml + publications.bib +
   # bio.md + news.md + EXTRACTION_REVIEW.md.
 
-aris-homepage render --persona theory-minimal [--out index.html] [--override-all] [--no-audit] [--offline]
+python tools/aris_homepage.py render --persona theory-minimal [--out index.html] [--override-all] [--no-audit] [--offline]
   # Run fact-check (unless --no-audit) and render. Hard-fail blocks ship unless
   # --override-all (loudly logged in audit-report.md).
 
-aris-homepage check [--strict]
+python tools/aris_homepage.py check [--strict]
   # Fact-check only; updates audit-report.md. --strict treats WARN as FAIL.
 
-aris-homepage doctor
+python tools/aris_homepage.py doctor
   # Environment + dependency diagnostic (Python, pyyaml, textutil, DBLP reachability).
 ```
 
@@ -133,22 +138,22 @@ Runs automatically during every `render` (unless `--no-audit`). Three outcomes p
 
 | Outcome | Trigger | Effect |
 |---|---|---|
-| **PASS (silent)** | Title fuzzy-matches DBLP; venue + year + author set agree | No mention in audit-report |
-| **WARN (soft)** | DBLP returns 0 hits OR ≥2 ambiguous; arXiv-only paper; award has no external URL | Render proceeds; logged in audit-report |
-| **FAIL (hard)** | DBLP venue ≠ profile venue; year mismatch; author list missing user; fabricated award badge; missing bibkey in publications.bib | HTML still renders but verdict = `BLOCKED`; user must `--override-all` to ship |
+| **PASS** | Title hits DBLP and nothing below fires. Year and venue are only compared when both the BibTeX entry and the DBLP hit carry them | Listed under `## ✅ Verified` in audit-report |
+| **WARN (soft)** | DBLP returns 0 hits OR ≥2 ambiguous; entry has an arXiv eprint but no DBLP record; BibTeX entry has no title | Render proceeds; logged in audit-report |
+| **FAIL (hard)** | DBLP venue ≠ the BibTeX `booktitle`/`journal`; year mismatch; a `best paper` / `spotlight` / `oral` / `outstanding` badge with no `arxiv`/`paper`/`pdf`/`project`/`openreview` link; bibkey in `selected_publications` missing from publications.bib; expired override | Verdict = `BLOCKED` and **`render` exits without writing the HTML**; `audit-report.md` is still written. `--override-all` to ship anyway |
 
 **Override two-layer**:
-- Per-paper, per-field in profile.yml: `audit.overrides.<bibkey>.<field>: true` with required `reason:` and optional `expires:` date
-- CLI emergency: `aris-homepage render --override-all` (every override loudly logged)
+- Per-paper in profile.yml: `audit.overrides.<bibkey>` — any non-empty, unexpired override object skips the DBLP checks for that paper entirely (it is not enforced per-field). `reason:` is recorded in the report but not required; `expires:` is, once past, a hard failure
+- CLI emergency: `python tools/aris_homepage.py render --override-all` (every override loudly logged)
 
-**Honest scope of fact-check**: catches venue/year/author mismatch and fabricated award claims. Does NOT verify: workshop papers without DBLP entries, industry tech reports, blog/talk content, OSS star counts, or arbitrary claims in the bio. Treat the audit as a **diagnostic floor**, not a guarantee.
+**Honest scope of fact-check**: DBLP lookups cover only the papers listed in `selected_publications`; the award-badge sweep covers every entry in `publications_meta`. It catches venue/year mismatch and award badges asserted without a link. It does **not** check author lists at all, and it never compares the title DBLP returned — the title is only the search query. Does NOT verify: workshop papers without DBLP entries, industry tech reports, blog/talk content, OSS star counts, or arbitrary claims in the bio. Treat the audit as a **diagnostic floor**, not a guarantee.
 
 ## Cross-model review — what's automated vs optional
 
 Two distinct review layers; do not confuse them:
 
 **Layer 1 — automated factual audit (always runs)**
-`aris-homepage render` and `aris-homepage check` run a deterministic Python pipeline that queries DBLP (with a 4-attempt backoff + local cache at `.aris-homepage/dblp-cache.json`) and falls back to arXiv hints. No external LLM needed. This is the **floor** of fact-check, and it works with **zero** AI-runtime dependencies beyond Python + the calling shell.
+`render` and `check` run a deterministic Python pipeline that queries DBLP (with a 4-attempt backoff + local cache at `.aris-homepage/dblp-cache.json`). Nothing queries arXiv: a DBLP miss is a WARN either way, and an `eprint` / `archiveprefix` field already in your BibTeX only changes how that warning is labelled. No external LLM needed. This is the **floor** of fact-check, and it works with **zero** AI-runtime dependencies beyond Python + the calling shell.
 
 **Layer 2 — optional adversarial LLM review (recommended for high-stakes)**
 If the calling agent has access to **Codex MCP** (`mcp__codex__codex`), run a fresh-thread Codex review after `render` to scrutinize: bio prose tone, claim phrasing, sub-project list, schema consistency. Codex acts as the cross-family reviewer (ARIS's adversarial-review invariant).
@@ -178,7 +183,7 @@ cv.{pdf,docx} ─►│ Step 1: extract → cv.txt                   │
                 └─────────────────┬────────────────────────┘
                                   ▼
                 ┌──────────────────────────────────────────┐
-                │ Step 3: aris-homepage finalize           │
+                │ Step 3: aris_homepage.py finalize        │
                 │   → profile.yml + publications.bib       │
                 │   + bio.md + news.md + EXTRACTION_REVIEW │
                 └─────────────────┬────────────────────────┘
@@ -188,7 +193,7 @@ cv.{pdf,docx} ─►│ Step 1: extract → cv.txt                   │
                                   ▼
                 ┌──────────────────────────────────────────┐
                 │ Step 4: render (with Layer-1 DBLP audit) │
-                │   ↳ Python DBLP/arXiv fact-check         │
+                │   ↳ Python DBLP fact-check               │
                 │   ↳ Python builds per-section HTML       │
                 │   ↳ inject into homepage-<persona>.html  │
                 │   ↳ (optional) Codex MCP adversarial pass│
@@ -207,9 +212,9 @@ cv.{pdf,docx} ─►│ Step 1: extract → cv.txt                   │
 - **DOCX**: `textutil` on macOS (bundled) OR `python-docx` (`pip install python-docx`)
 - **PDF**: `pdftotext` (install via `brew install poppler` / `apt install poppler-utils`)
 - **DBLP**: official `https://dblp.org/search/publ/api` (rate-limited 4-attempt backoff + local cache in `.aris-homepage/dblp-cache.json`)
-- **Codex MCP**: for cross-model factual audit (required for the audit; the generator runs without it via `--no-audit`)
+- **Codex MCP**: optional, for the Layer-2 adversarial review only. The Layer-1 DBLP audit is pure Python and needs no LLM.
 
-`aris-homepage doctor` checks all of the above.
+`python tools/aris_homepage.py doctor` checks all of the above.
 
 ## Privacy and generic examples
 
@@ -236,11 +241,11 @@ The public demo at `wanshuiyin.github.io` is the **only exception** — it's an 
 
 ## Acceptance criteria (v1 done)
 
-1. `aris-homepage init --from-cv` produces editable scaffolding from any user's CV (single-file `.docx` or `.pdf`).
-2. `aris-homepage render --persona theory-minimal` produces a single HTML file ≤500KB (no images) or ≤2MB (with photo + thumbnails inline), or smaller still when images are referenced via remote URLs.
+1. `python tools/aris_homepage.py init --from-cv` produces editable scaffolding from any user's CV (single-file `.docx` or `.pdf`).
+2. `python tools/aris_homepage.py render --persona theory-minimal` produces a single HTML file ≤500KB (no images) or ≤2MB (with photo + thumbnails inline), or smaller still when images are referenced via remote URLs.
 3. Fact-check correctly hard-fails on a corrupted profile.yml (e.g., venue swap NeurIPS↔ICML) and passes when corrected.
 4. The HTML is publishable on GitHub Pages / Netlify / S3 / any static host without a build step.
-5. `aris-homepage doctor` accurately reports environment readiness.
+5. `python tools/aris_homepage.py doctor` accurately reports environment readiness.
 6. No personal info from the maintainer's dogfood leaks into shipped examples or tests.
 
 ## What's deferred (v1.1+)

--- a/skills/homepage-generator/WINDOWS.md
+++ b/skills/homepage-generator/WINDOWS.md
@@ -60,7 +60,7 @@ python .\tools\aris_homepage.py <子命令> <参数...>
 
 ❌ **不要**用 `python3`（原因见第 1 步）。
 
-❌ **不要**照着主 README 的 quick start 敲 `aris-homepage` —— 这个命令不存在。仓库没有提供任何安装器，脚本永远只能用 `python <路径>\aris_homepage.py` 的方式调。另外注意文件名是**下划线** `aris_homepage.py`，不是连字符。
+❌ **不要**敲 `aris-homepage` —— 这个命令不存在。仓库没有提供任何安装器，脚本永远只能用 `python <路径>\aris_homepage.py` 的方式调。旧文档或博客里如果看到这种写法，那是过时的。另外注意文件名是**下划线** `aris_homepage.py`，不是连字符。
 
 ✅ 正确示例：
 

--- a/skills/homepage-generator/WINDOWS_en.md
+++ b/skills/homepage-generator/WINDOWS_en.md
@@ -60,7 +60,7 @@ python .\tools\aris_homepage.py <subcommand> <args...>
 
 ❌ **Don't** use `python3` (see step 1).
 
-❌ **Don't** type `aris-homepage`. Despite what the main README's quick start shows, there is no such command — the repo ships no installer, so the script is only ever reachable as `python <path>\aris_homepage.py`. Note the **underscore** in the filename, not a hyphen.
+❌ **Don't** type `aris-homepage`. No such command exists — the repo ships no installer, so the script is only ever reachable as `python <path>\aris_homepage.py`. If you find that form in an older doc or blog post, it is stale. Note the **underscore** in the filename, not a hyphen.
 
 ✅ Correct:
 

--- a/tools/aris_homepage.py
+++ b/tools/aris_homepage.py
@@ -7,7 +7,7 @@ Pipeline:
     init --from-cv  →  textutil → emit extraction handoff JSON → user's calling LLM
                        fills .aris-homepage/extraction.json → this script persists
                        to profile.yml + publications.bib + bio.md + news.md
-    render          →  load → fact-check (DBLP/arXiv) → Python builds HTML chunks
+    render          →  load → fact-check (DBLP) → Python builds HTML chunks
                        → injects into homepage-<persona>.html template
     check           →  fact-check only, update audit-report.md
     doctor          →  environment diagnostic
@@ -31,6 +31,7 @@ import hashlib
 import html as html_lib
 import json
 import mimetypes
+import os
 import re
 import shutil
 import subprocess
@@ -56,7 +57,30 @@ except ImportError:
 
 SCHEMA_VERSION = 1
 DBLP_API = "https://dblp.org/search/publ/api"
-ARXIV_API = "http://export.arxiv.org/api/query"
+
+
+def short_path(p: Path, from_dir: Path | None = None) -> str:
+    """Whichever of the relative / absolute form of ``p`` is shorter to read.
+
+    A relative path is friendlier from inside the repo, but climbing out of a
+    site workspace on another branch of the filesystem produces ../../../..
+    noise that is worse than just printing the absolute path.
+    """
+    rel = os.path.relpath(p, from_dir or Path.cwd())
+    return rel if len(rel) < len(str(p)) else str(p)
+
+
+def invocation(from_dir: Path | None = None) -> str:
+    """How to re-run this script from ``from_dir`` (default: the current directory).
+
+    There is no installed ``aris-homepage`` command — this repo ships no entry
+    point — so every "run this next" message has to spell out the interpreter
+    and a path valid from where the user will actually be standing. That is not
+    always where they are now: ``render`` and ``check`` operate on the site
+    workspace, so their commands must be written relative to it.
+    """
+    return f"python {short_path(Path(__file__).resolve(), from_dir)}"
+
 
 DEFAULT_FILES = {
     "profile": "profile.yml",
@@ -520,7 +544,7 @@ def print_extraction_handoff(txt_path: Path, out_dir: Path,
     This script does NOT call an LLM — the calling agent (Claude/Gemini)
     reads cv.txt + optional github_repos.json, fills the JSON-schema-constrained
     output, and writes .aris-homepage/extraction.json. A follow-up
-    `aris-homepage finalize` ingests that JSON and writes the editable sources.
+    ``<this script> finalize`` ingests that JSON and writes the editable sources.
     """
     handoff_path = out_dir / ".aris-homepage" / "EXTRACTION_HANDOFF.md"
     schema_path = out_dir / ".aris-homepage" / "extraction.schema.json"
@@ -571,7 +595,7 @@ Write the JSON output to:
   .aris-homepage/extraction.json
 
 Then run:
-  aris-homepage finalize
+  {invocation()} finalize --out {short_path(out_dir)}
 
 …to persist the structured fields into profile.yml + publications.bib + bio.md + news.md.
 
@@ -592,13 +616,13 @@ Then run:
 > - Do NOT invent claims. If the CV doesn't say something, leave the field null/empty.
 > - Identify the CV owner. Their name goes in profile.identity.name + name_native (if bilingual).
 {('> - If github_repos.json exists, merge its timeline into news_md following the rules in the section above.' + chr(10)) if repos_block else ''}>
-> After writing the JSON, instruct the user to run `aris-homepage finalize`.
+> After writing the JSON, instruct the user to run `{invocation()} finalize --out {short_path(out_dir)}`.
 """, encoding="utf-8")
     print(f"✓ CV text extracted to: {txt_path}")
     print(f"✓ Extraction handoff written to: {handoff_path}")
     print()
     print("Next: read the handoff doc and fill .aris-homepage/extraction.json,")
-    print("      then run `aris-homepage finalize` to persist the structured files.")
+    print(f"      then run `{invocation()} finalize --out {short_path(out_dir)}` to persist the structured files.")
 
 
 def cmd_finalize(args: argparse.Namespace) -> int:
@@ -606,7 +630,7 @@ def cmd_finalize(args: argparse.Namespace) -> int:
     workspace = Path(args.out).resolve() if args.out else Path(".").resolve()
     extraction_path = workspace / ".aris-homepage" / "extraction.json"
     if not extraction_path.exists():
-        die(f"{extraction_path} not found. Run `aris-homepage init --from-cv ...` first, "
+        die(f"{extraction_path} not found. Run `{invocation()} init --from-cv ...` first, "
             f"then have the calling agent fill the extraction JSON.")
 
     data = json.loads(extraction_path.read_text(encoding="utf-8"))
@@ -633,7 +657,8 @@ def cmd_finalize(args: argparse.Namespace) -> int:
     review_lines = ["# Extraction Review", "",
                     "These claims were extracted from your CV but could not be auto-verified.",
                     "Edit the corresponding files (profile.yml, publications.bib, bio.md, news.md)",
-                    "as needed, then run `aris-homepage render --persona theory-minimal`.", ""]
+                    f"as needed, then run `{invocation(workspace)} render --persona theory-minimal`",
+                    "from inside this directory.", ""]
     if uncertain:
         review_lines.append("## ⚠️ Uncertain claims (review before rendering)")
         review_lines.append("")
@@ -652,8 +677,9 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         print(f"✓ Wrote {DEFAULT_FILES['news']}")
     print(f"✓ Wrote {DEFAULT_FILES['extraction_review']}")
     print()
-    print("Edit the files as needed, then run:")
-    print("  aris-homepage render --persona theory-minimal")
+    print("Edit the files as needed, then render from the site directory:")
+    print(f"  cd {short_path(workspace)}")
+    print(f"  {invocation(workspace)} render --persona theory-minimal")
     return 0
 
 
@@ -709,7 +735,7 @@ def load_profile(path: Path) -> dict[str, Any]:
     if not HAS_YAML:
         die("pyyaml not installed. Run: pip install pyyaml --break-system-packages")
     if not path.exists():
-        die(f"{path} not found. Run `aris-homepage init --from-cv <cv>` first.")
+        die(f"{path} not found. Run `{invocation()} init --from-cv <cv>` first.")
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         die(f"{path}: expected a YAML mapping at top level.")
@@ -1391,7 +1417,7 @@ def run_fact_check(profile: dict, bib: dict, *, override_all: bool = False,
                 "detail": "bibkey listed in selected_publications but not in publications.bib",
             })
 
-    # Per-paper DBLP/arXiv check
+    # Per-paper DBLP check
     for key in selected:
         if key not in bib:
             continue
@@ -1659,7 +1685,7 @@ def write_audit_report(path: Path, audit: AuditResult, profile: dict, persona: s
         lines.append("")
     lines.append("---")
     lines.append("Generated by [ARIS-Homepage](https://github.com/wanshuiyin/ARIS-in-AI-Offer). "
-                 "Re-run `aris-homepage check` after edits.")
+                 f"Re-run `{invocation(path.parent)} check` from this directory after edits.")
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -1762,7 +1788,7 @@ def die(msg: str) -> None:
 
 def main() -> int:
     p = argparse.ArgumentParser(
-        prog="aris-homepage",
+        prog=invocation(),
         description="Generate a fact-checked academic homepage from a CV.",
     )
     sub = p.add_subparsers(dest="cmd", required=True)

--- a/tools/aris_homepage.py
+++ b/tools/aris_homepage.py
@@ -595,7 +595,8 @@ Write the JSON output to:
   .aris-homepage/extraction.json
 
 Then run:
-  {invocation()} finalize --out {short_path(out_dir)}
+  cd {short_path(out_dir)}
+  {invocation(out_dir)} finalize
 
 …to persist the structured fields into profile.yml + publications.bib + bio.md + news.md.
 
@@ -616,13 +617,14 @@ Then run:
 > - Do NOT invent claims. If the CV doesn't say something, leave the field null/empty.
 > - Identify the CV owner. Their name goes in profile.identity.name + name_native (if bilingual).
 {('> - If github_repos.json exists, merge its timeline into news_md following the rules in the section above.' + chr(10)) if repos_block else ''}>
-> After writing the JSON, instruct the user to run `{invocation()} finalize --out {short_path(out_dir)}`.
+> After writing the JSON, instruct the user to `cd` into `{short_path(out_dir)}` and run `{invocation(out_dir)} finalize`.
 """, encoding="utf-8")
     print(f"✓ CV text extracted to: {txt_path}")
     print(f"✓ Extraction handoff written to: {handoff_path}")
     print()
-    print("Next: read the handoff doc and fill .aris-homepage/extraction.json,")
-    print(f"      then run `{invocation()} finalize --out {short_path(out_dir)}` to persist the structured files.")
+    print("Next: read the handoff doc and fill .aris-homepage/extraction.json, then:")
+    print(f"  cd {short_path(out_dir)}")
+    print(f"  {invocation(out_dir)} finalize")
 
 
 def cmd_finalize(args: argparse.Namespace) -> int:


### PR DESCRIPTION
Three documented behaviours the code never had, surfaced while reviewing #40 / #43. Docs + one script change; no behaviour change to the audit itself.

### 1. The audit does not check author lists

`run_fact_check()` compares year and venue and sanity-checks award badges. It never inspects authors. README, README_CN and `SKILL.md` all said it did — including `SKILL.md`'s FAIL trigger "author list missing user", which can't fire.

### 2. Nothing queries arXiv

`ARXIV_API` was defined and never called. The "arXiv fallback" only reads an `eprint` / `archiveprefix` field already present in your BibTeX, and only to label the warning — a DBLP miss is a WARN either way. Dead constant removed; "DBLP / arXiv" corrected everywhere, both pipeline diagrams included.

### 3. `aris-homepage` is not a command

No installer, no entry point — so the quick starts, the command reference, argparse's `prog=` (which printed `usage: aris-homepage ...`) and eight "run this next" messages all named something that does not exist on any platform.

They now emit `python <path>/aris_homepage.py`, resolved against the directory the user will actually be standing in. That distinction matters: `finalize`, `render` and `check` act on the site workspace, so a path computed from the current directory goes stale the moment the documented `cd ./site` happens. The first version of this fix got that wrong; the reviewer caught it.

### Also corrected — the fact-check protocol table, same defect class

Found while fixing (1), in the cells next to it:

| Was | Actually |
|---|---|
| hard FAIL → "HTML still renders but verdict = `BLOCKED`" | `render` returns **before** writing any HTML; only `audit-report.md` appears |
| PASS → "no mention in audit-report" | passed items are listed under `## ✅ Verified` |
| "DBLP venue ≠ profile venue" | compared against the BibTeX `booktitle`/`journal` |
| any unlinked award badge fails | only `best paper` / `spotlight` / `oral` / `outstanding`, and only `arxiv`/`paper`/`pdf`/`project`/`openreview` count as a link |
| overrides are per-field with a required `reason:` | per-paper; any non-empty unexpired override skips that paper's DBLP checks, and `reason:` is recorded but not enforced |
| Codex MCP "required for the audit" | Layer 1 is pure Python and needs no LLM |

### Verification

End-to-end on a scratch workspace: `init` → `finalize` → `render` now emit a copy-pasteable command at every step, and a BLOCKED audit writes `audit-report.md` with no `index.html` — the behaviour the table had backwards. `tools/verify_reviews.py --mode strict --reproduce` stays green.

Reviewed by gpt-5.6-sol xhigh (thread `01a0285f`).

> **Merge order:** #43 also touches `README.md`, `README_CN.md` and `SKILL.md`. Merge #43 first and this branch will need a small rebase; the overlapping regions are adjacent but distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkzGJUXJSUxdgrsjJtjAn6