### PR TITLE
docs(tutorials): attention §3.5 — fused QKV + chunk, and the GQA chunk(3) trap

### DIFF
--- a/docs/tutorials/attention_tutorial.html
+++ b/docs/tutorials/attention_tutorial.html
@@ -7,8 +7,8 @@
 
 <meta name="generator" content="ARIS render-html (academic, v1)">
 <meta name="aris:source-path" content="docs/tutorials/attention_tutorial.md">
-<meta name="aris:source-sha256" content="ea13435c65f9bce9a064bd65d9e492652b6492beba86d95fdc7639221cd02a02">
-<meta name="aris:generated-at" content="2026-07-31 02:58 UTC">
+<meta name="aris:source-sha256" content="e8650ca7b3dac4fed8301ee38a559f0bc463e685b22bbe1fc04fc950d1f738c9">
+<meta name="aris:generated-at" content="2026-08-24 03:10 UTC">
 
 <!-- MathJax 3 -->
 <script>
@@ -545,6 +545,7 @@ body.aris-blog .aris-focus-toggle { display: inline-block; }
 <li><a href="#32-为什么要-multi-head不是单-head-也行吗">3.2　为什么要 multi-head（不是单 head 也行吗？）</a></li>
 <li><a href="#33-参数量与-flops">3.3　参数量与 FLOPs</a></li>
 <li><a href="#34-代码核心-30-行">3.4　代码（核心 30 行）</a></li>
+<li><a href="#35-fused-qkv--chunk-写法工程实现都这么写">3.5　fused QKV + chunk 写法（工程实现都这么写）</a></li>
 </ul>
 </li>
 <li><a href="#4-self--cross--causal--padding">§4 Self / Cross / Causal / Padding</a>
@@ -597,8 +598,8 @@ body.aris-blog .aris-focus-toggle { display: inline-block; }
   
   <div class="meta">
     <span><strong>Source:</strong> <code>docs/tutorials/attention_tutorial.md</code></span>
-    <span><strong>SHA256:</strong> <code>ea13435c65f9</code></span>
-    <span><strong>Rendered:</strong> 2026-07-31 02:58 UTC</span>
+    <span><strong>SHA256:</strong> <code>e8650ca7b3da</code></span>
+    <span><strong>Rendered:</strong> 2026-08-24 03:10 UTC</span>
     
   </div>
 </header>
@@ -726,6 +727,28 @@ W_o ∈ R^{D×D}    →    Output [B, L_q, D]</code></pre>
 
         out, w = scaled_dot_product_attention(Q, K, V, mask=mask, dropout_p=self.dropout_p, training=self.training)
         return self.W_o(self._merge(out)), w</code></pre>
+<h3 id="35-fused-qkv--chunk-写法工程实现都这么写">3.5　fused QKV + chunk 写法（工程实现都这么写）</h3>
+<p>§3.4 用三个独立的 <code>W_q / W_k / W_v</code>，读起来最贴公式。<strong>self-attention</strong> 实现里更常见的是把三个投影<strong>合成一个 Linear</strong>，再把输出切开——nanoGPT、HF GPT-2、timm 的 ViT 都是这个写法（也有反例：HF LLaMA 就保持三个独立的 <code>q_proj / k_proj / v_proj</code>；cross-attention 则根本没法 fuse，因为 Q 和 K/V 来自不同输入）。下面三种切法<strong>逐元素完全相同</strong>（<code>torch.equal</code> 为 True），彼此只差可读性；省 GEMM 是 fused 相对 §3.4 三个 Linear 而言的。</p>
+<pre><code class="language-python">D, H, d_k = 64, 4, 16                       # D = H * d_k
+qkv_proj = nn.Linear(D, 3 * D, bias=False)  # 一个 Linear 产出 Q/K/V
+qkv = qkv_proj(x)                           # [B, N, 3D]
+
+# 写法 1：chunk —— 最好读，白板上不容易写错
+q, k, v = qkv.chunk(3, dim=-1)                          # 每个 [B, N, D]
+q, k, v = [t.view(B, N, H, d_k).transpose(1, 2)         # → [B, H, N, d_k]
+           for t in (q, k, v)]
+
+# 写法 2：nanoGPT 的 split —— 与 chunk 等价（3D/3 = D），后面同样要接 view+transpose
+q, k, v = qkv.split(D, dim=2)
+q, k, v = [t.view(B, N, H, d_k).transpose(1, 2) for t in (q, k, v)]
+
+# 写法 3：5-D reshape + permute —— timm ViT / 本仓库 code/mha.py 用的
+q, k, v = qkv.reshape(B, N, 3, H, d_k).permute(2, 0, 3, 1, 4)</code></pre>
+<div class="callout callout-info"><div class="callout-title">为什么要 fuse</div><p>相比 §3.4 的三个 Linear，Q/K/V 只需<strong>一次 GEMM</strong> 而不是三次。FLOPs 完全一样，省的是 kernel launch 和激活读写，大矩阵乘的硬件利用率通常也更好（幅度取决于形状和后端）。另一个现实理由是权重排布——HF GPT-2 的 <code>c_attn</code>（<code>Conv1D</code>，权重 <code>[D, 3D]</code>）就是 Q/K/V 沿输出维按 <code>[Q | K | V]</code> 顺序拼的，想加载预训练权重就必须对齐这个顺序（搬到 <code>nn.Linear</code> 还得转置成 <code>[3D, D]</code>）。</p></div>
+<div class="table-wrap"><table><thead><tr><th>写法</th><th>切分</th><th>可读性</th><th>用在哪</th></tr></thead><tbody><tr><td>三个独立 Linear</td><td>不用切</td><td>最贴公式</td><td>教学代码、§3.4</td></tr><tr><td>fused + <code>chunk(3, dim=-1)</code></td><td>均分三份</td><td><strong>最好</strong></td><td>大部分手写实现</td></tr><tr><td>fused + <code>split(D, dim=2)</code></td><td>每份宽 D</td><td>好</td><td>nanoGPT</td></tr><tr><td>fused + <code>reshape</code> + 5-D <code>permute</code></td><td>一步到位</td><td>差，容易写错轴顺序</td><td>timm ViT、<code>code/mha.py</code></td></tr></tbody></table></div>
+<div class="callout callout-warn"><div class="callout-title">GQA 一来 `chunk(3)` 就是错的（高频追问）</div><p>MQA/GQA 下 fused 投影不再是三等份，而是 <code>D + 2·G·d_k</code>（见 §6.2）。取 <code>D=64, H=4, d_k=16, G=2</code>，fused 宽度是 <code>64 + 32 + 32 = 128</code>，<code>chunk(3)</code> 切出来是 <code>[43, 43, 42]</code>——<strong>它不报错</strong>，Q 拿到 43 而不是 64，要等到后面 <code>view</code> 才炸出一句和真正病因毫无关系的 <code>shape &#x27;[2, 7, 4, 16]&#x27; is invalid for input of size 602</code>。</p></div>
+<p><code>torch.chunk</code> 除不尽时不会抛异常，只是给出不等长的几份（宽 5 分 3 份 → <code>[2, 2, 1]</code>）。所以规则很简单：<strong>Q 和 K/V 头数不一致的结构，一律用 <code>split</code> 显式给出三段宽度，别用 <code>chunk</code>。</strong></p>
+<pre><code class="language-python">q, k, v = qkv.split([D, G * d_k, G * d_k], dim=-1)      # 显式宽度，MQA/GQA 下的标准写法</code></pre>
 <h2 id="4-self--cross--causal--padding">§4 Self / Cross / Causal / Padding</h2>
 <h3 id="41-self-vs-cross-attention必考">4.1　Self vs Cross Attention（必考）</h3>
 <div class="table-wrap"><table><thead><tr><th></th><th>Self-Attention</th><th>Cross-Attention</th></tr></thead><tbody><tr><td><strong>Q 来源</strong></td><td>$X$</td><td>$X_\text{decoder}$ / latent / learnable queries</td></tr><tr><td><strong>K, V 来源</strong></td><td>$X$（同源）</td><td>$X_\text{encoder}$ / context / memory</td></tr><tr><td><strong>$L_q$ vs $L_k$</strong></td><td>相等</td><td>可以不同</td></tr><tr><td><strong>典型 mask</strong></td><td>causal (decoder) 或 padding (encoder)</td><td>K/V 端 padding mask（不用 causal）</td></tr><tr><td><strong>用途</strong></td><td>内部位置相关性</td><td>从外部 memory 检索相关信息</td></tr><tr><td><strong>例子</strong></td><td>BERT 各层；GPT 各层；ViT</td><td>Transformer Decoder 第二子层；DETR；Perceiver；Stable Diffusion (image Q × text K/V)</td></tr></tbody></table></div>
@@ -973,8 +996,8 @@ All checks passed.</code></pre>
 <footer class="aris-footer">
   Generated by <a href="https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep/blob/main/skills/render-html/SKILL.md">ARIS <code>/render-html</code></a> ·
   source path <code>docs/tutorials/attention_tutorial.md</code> ·
-  SHA256 <code>ea13435c65f9</code> ·
-  generated at 2026-07-31 02:58 UTC.
+  SHA256 <code>e8650ca7b3da</code> ·
+  generated at 2026-08-24 03:10 UTC.
   This is a generated view — edit the source Markdown, then re-render.
 </footer>
 </main>

--- a/docs/tutorials/attention_tutorial.md
+++ b/docs/tutorials/attention_tutorial.md
@@ -219,6 +219,45 @@ class MultiHeadAttention(nn.Module):
         return self.W_o(self._merge(out)), w
 ```
 
+### 3.5　fused QKV + chunk 写法（工程实现都这么写）
+
+§3.4 用三个独立的 `W_q / W_k / W_v`，读起来最贴公式。**self-attention** 实现里更常见的是把三个投影**合成一个 Linear**，再把输出切开——nanoGPT、HF GPT-2、timm 的 ViT 都是这个写法（也有反例：HF LLaMA 就保持三个独立的 `q_proj / k_proj / v_proj`；cross-attention 则根本没法 fuse，因为 Q 和 K/V 来自不同输入）。下面三种切法**逐元素完全相同**（`torch.equal` 为 True），彼此只差可读性；省 GEMM 是 fused 相对 §3.4 三个 Linear 而言的。
+
+```python
+D, H, d_k = 64, 4, 16                       # D = H * d_k
+qkv_proj = nn.Linear(D, 3 * D, bias=False)  # 一个 Linear 产出 Q/K/V
+qkv = qkv_proj(x)                           # [B, N, 3D]
+
+# 写法 1：chunk —— 最好读，白板上不容易写错
+q, k, v = qkv.chunk(3, dim=-1)                          # 每个 [B, N, D]
+q, k, v = [t.view(B, N, H, d_k).transpose(1, 2)         # → [B, H, N, d_k]
+           for t in (q, k, v)]
+
+# 写法 2：nanoGPT 的 split —— 与 chunk 等价（3D/3 = D），后面同样要接 view+transpose
+q, k, v = qkv.split(D, dim=2)
+q, k, v = [t.view(B, N, H, d_k).transpose(1, 2) for t in (q, k, v)]
+
+# 写法 3：5-D reshape + permute —— timm ViT / 本仓库 code/mha.py 用的
+q, k, v = qkv.reshape(B, N, 3, H, d_k).permute(2, 0, 3, 1, 4)
+```
+
+> 💡 **为什么要 fuse** —— 相比 §3.4 的三个 Linear，Q/K/V 只需**一次 GEMM** 而不是三次。FLOPs 完全一样，省的是 kernel launch 和激活读写，大矩阵乘的硬件利用率通常也更好（幅度取决于形状和后端）。另一个现实理由是权重排布——HF GPT-2 的 `c_attn`（`Conv1D`，权重 `[D, 3D]`）就是 Q/K/V 沿输出维按 `[Q | K | V]` 顺序拼的，想加载预训练权重就必须对齐这个顺序（搬到 `nn.Linear` 还得转置成 `[3D, D]`）。
+
+| 写法 | 切分 | 可读性 | 用在哪 |
+| --- | --- | --- | --- |
+| 三个独立 Linear | 不用切 | 最贴公式 | 教学代码、§3.4 |
+| fused + `chunk(3, dim=-1)` | 均分三份 | **最好** | 大部分手写实现 |
+| fused + `split(D, dim=2)` | 每份宽 D | 好 | nanoGPT |
+| fused + `reshape` + 5-D `permute` | 一步到位 | 差，容易写错轴顺序 | timm ViT、`code/mha.py` |
+
+> ⚠️ **GQA 一来 `chunk(3)` 就是错的（高频追问）** —— MQA/GQA 下 fused 投影不再是三等份，而是 `D + 2·G·d_k`（见 §6.2）。取 `D=64, H=4, d_k=16, G=2`，fused 宽度是 `64 + 32 + 32 = 128`，`chunk(3)` 切出来是 `[43, 43, 42]`——**它不报错**，Q 拿到 43 而不是 64，要等到后面 `view` 才炸出一句和真正病因毫无关系的 `shape '[2, 7, 4, 16]' is invalid for input of size 602`。
+
+`torch.chunk` 除不尽时不会抛异常，只是给出不等长的几份（宽 5 分 3 份 → `[2, 2, 1]`）。所以规则很简单：**Q 和 K/V 头数不一致的结构，一律用 `split` 显式给出三段宽度，别用 `chunk`。**
+
+```python
+q, k, v = qkv.split([D, G * d_k, G * d_k], dim=-1)      # 显式宽度，MQA/GQA 下的标准写法
+```
+
 ## §4 Self / Cross / Causal / Padding
 
 ### 4.1　Self vs Cross Attention（必考）

--- a/docs/tutorials/attention_tutorial.review.json
+++ b/docs/tutorials/attention_tutorial.review.json
@@ -1,7 +1,7 @@
 {
   "skill": "render-html",
   "source": "docs/tutorials/attention_tutorial.md",
-  "source_sha256_prefix": "ea13435c65f9bce9",
+  "source_sha256_prefix": "e8650ca7b3dac4fe",
   "output": "docs/tutorials/attention_tutorial.html",
   "author": "Ruofeng Yang (杨若峰), Shanghai Jiao Tong University",
   "reviewer": "codex gpt-5.5 xhigh, fresh thread per run (never codex-reply)",
@@ -61,7 +61,7 @@
   ],
   "summary": "Three-round review: FAIL (table-pipe math collision) → FAIL (TL;DR list numbering reset) → PASS. 13 checks pass on run 3.",
   "rendered_at": "2026-05-19",
-  "source_sha256": "ea13435c65f9bce9a064bd65d9e492652b6492beba86d95fdc7639221cd02a02",
+  "source_sha256": "e8650ca7b3dac4fed8301ee38a559f0bc463e685b22bbe1fc04fc950d1f738c9",
   "thread_id": "019e7c8b-66fc-7ca2-bde6-c9f03aa3b224",
   "post_ship_review": [
     {
@@ -80,6 +80,24 @@
         "§A appendix sanity-check transcript's exception type corrected ValueError -> AssertionError, matching both mha.py's actual `assert embed_dim % num_heads == 0` and the tutorial's own §3.4 code snippet; added a note that `assert` is stripped under python -O (CONFIRMED)"
       ],
       "note": "Verification and fixes limited to attention_tutorial.md / _en.md; code/mha.py itself was read to confirm ground truth and left unmodified. Re-rendered both HTMLs and refreshed source_sha256 (this run); gated via tools/verify_reviews.py --mode strict --reproduce."
+    }
+  ],
+  "delta_reviews": [
+    {
+      "run": "delta-2026-08-24",
+      "scope": "New §3.5 only (fused QKV: chunk / split / 5-D reshape+permute; GQA chunk(3) trap). No other content touched.",
+      "verdict": "PASS after 1 fix round",
+      "reviewer": "codex gpt-5.6-sol xhigh, fresh thread",
+      "thread_id": "01a031ba-d74f-7cb2-859e-fc75f24ec2ea",
+      "process": "Claims verified on a real PyTorch box before drafting (all three slicing forms torch.equal; GQA chunk(3) widths [43,43,42] failing later at view; chunk on width 5 -> [2,2,1]). Reviewer then re-derived all six claims and audited prose.",
+      "findings_fixed": [
+        "Form 2 (split) as printed stopped at [B,N,D] — missing the same view+transpose the chunk form gets; added, re-verified verbatim.",
+        "'differ only in GEMM count' compared the wrong pair — the three slicing forms share one GEMM; 3-to-1 is fused vs §3.4's three Linears. Reworded.",
+        "GPT-2 c_attn orientation: it is a Conv1D with weight [D,3D], Q/K/V concatenated along the OUTPUT dim — 'stacked vertically' described the transposed nn.Linear layout. Corrected, with the transpose note.",
+        "'real code almost always fuses' overstated — scoped to self-attention, with HF LLaMA (separate q/k/v_proj) and cross-attention (cannot fuse) as counterexamples.",
+        "'far better' tensor-core utilisation softened to shape/backend-dependent.",
+        "'the only correct form under MQA/GQA' narrowed to the true rule: never equal-chunk(3) unequal widths; explicit-width split is the standard form."
+      ]
     }
   ]
 }

--- a/docs/tutorials/attention_tutorial_en.html
+++ b/docs/tutorials/attention_tutorial_en.html
@@ -7,8 +7,8 @@
 
 <meta name="generator" content="ARIS render-html (academic, v1)">
 <meta name="aris:source-path" content="docs/tutorials/attention_tutorial_en.md">
-<meta name="aris:source-sha256" content="f057c218d5b6435d443d904c25e0e732705172efce84a0918a984c166a516800">
-<meta name="aris:generated-at" content="2026-07-31 02:58 UTC">
+<meta name="aris:source-sha256" content="49459d52a2bdc516d301d1195f04ce1b0188136e1d0848c8538f8d82b2035110">
+<meta name="aris:generated-at" content="2026-08-24 03:10 UTC">
 
 <!-- MathJax 3 -->
 <script>
@@ -545,6 +545,7 @@ body.aris-blog .aris-focus-toggle { display: inline-block; }
 <li><a href="#32-why-multi-head-would-a-single-head-work">3.2　Why multi-head (would a single head work?)</a></li>
 <li><a href="#33-parameter-count-and-flops">3.3　Parameter count and FLOPs</a></li>
 <li><a href="#34-code-core-30-lines">3.4　Code (core 30 lines)</a></li>
+<li><a href="#35-fused-qkv--chunk-what-production-code-actually-writes">3.5　Fused QKV + chunk (what production code actually writes)</a></li>
 </ul>
 </li>
 <li><a href="#4-self--cross--causal--padding">§4 Self / Cross / Causal / Padding</a>
@@ -597,8 +598,8 @@ body.aris-blog .aris-focus-toggle { display: inline-block; }
   
   <div class="meta">
     <span><strong>Source:</strong> <code>docs/tutorials/attention_tutorial_en.md</code></span>
-    <span><strong>SHA256:</strong> <code>f057c218d5b6</code></span>
-    <span><strong>Rendered:</strong> 2026-07-31 02:58 UTC</span>
+    <span><strong>SHA256:</strong> <code>49459d52a2bd</code></span>
+    <span><strong>Rendered:</strong> 2026-08-24 03:10 UTC</span>
     
   </div>
 </header>
@@ -726,6 +727,28 @@ W_o ∈ R^{D×D}    →    Output [B, L_q, D]</code></pre>
 
         out, w = scaled_dot_product_attention(Q, K, V, mask=mask, dropout_p=self.dropout_p, training=self.training)
         return self.W_o(self._merge(out)), w</code></pre>
+<h3 id="35-fused-qkv--chunk-what-production-code-actually-writes">3.5　Fused QKV + chunk (what production code actually writes)</h3>
+<p>§3.4 uses three separate <code>W_q / W_k / W_v</code>, which reads closest to the formula. For <strong>self-attention</strong>, the more common production form <strong>fuses the three projections into one Linear</strong> and then slices the output — nanoGPT, HF GPT-2 and timm's ViT all do it this way (counterexamples exist: HF LLaMA keeps separate <code>q_proj / k_proj / v_proj</code>, and cross-attention cannot fuse at all, since Q and K/V come from different inputs). The three slicings below are <strong>element-wise identical</strong> (<code>torch.equal</code> returns True) and differ only in readability; the GEMM saving is fused-versus-§3.4's-three-Linears.</p>
+<pre><code class="language-python">D, H, d_k = 64, 4, 16                       # D = H * d_k
+qkv_proj = nn.Linear(D, 3 * D, bias=False)  # one Linear emits Q/K/V
+qkv = qkv_proj(x)                           # [B, N, 3D]
+
+# Form 1: chunk — the most readable, hardest to get wrong on a whiteboard
+q, k, v = qkv.chunk(3, dim=-1)                          # each [B, N, D]
+q, k, v = [t.view(B, N, H, d_k).transpose(1, 2)         # → [B, H, N, d_k]
+           for t in (q, k, v)]
+
+# Form 2: nanoGPT&#x27;s split — equivalent to chunk here (3D/3 = D); same view+transpose follows
+q, k, v = qkv.split(D, dim=2)
+q, k, v = [t.view(B, N, H, d_k).transpose(1, 2) for t in (q, k, v)]
+
+# Form 3: 5-D reshape + permute — timm ViT / this repo&#x27;s code/mha.py
+q, k, v = qkv.reshape(B, N, 3, H, d_k).permute(2, 0, 3, 1, 4)</code></pre>
+<div class="callout callout-info"><div class="callout-title">Why fuse</div><p>compared with §3.4's three Linears, Q/K/V cost <strong>one GEMM instead of three</strong>. The FLOPs are identical; what you save is kernel launches and activation traffic, and one large matmul usually utilises the hardware better (how much depends on shapes and backend). The other reason is weight layout: HF GPT-2's <code>c_attn</code> (a <code>Conv1D</code> with weight <code>[D, 3D]</code>) concatenates Q/K/V along the output dimension in <code>[Q | K | V]</code> order, so loading pretrained weights requires matching that order (and a transpose to <code>[3D, D]</code> if you port it to <code>nn.Linear</code>).</p></div>
+<div class="table-wrap"><table><thead><tr><th>Form</th><th>How it slices</th><th>Readability</th><th>Used by</th></tr></thead><tbody><tr><td>Three separate Linears</td><td>no slicing</td><td>closest to the math</td><td>teaching code, §3.4</td></tr><tr><td>fused + <code>chunk(3, dim=-1)</code></td><td>three equal parts</td><td><strong>best</strong></td><td>most hand-written implementations</td></tr><tr><td>fused + <code>split(D, dim=2)</code></td><td>parts of width D</td><td>good</td><td>nanoGPT</td></tr><tr><td>fused + <code>reshape</code> + 5-D <code>permute</code></td><td>one shot</td><td>poor — easy to get the axis order wrong</td><td>timm ViT, <code>code/mha.py</code></td></tr></tbody></table></div>
+<div class="callout callout-warn"><div class="callout-title">`chunk(3)` becomes wrong the moment you use GQA (a common follow-up)</div><p>under MQA/GQA the fused projection is no longer three equal parts but <code>D + 2·G·d_k</code> (see §6.2). Take <code>D=64, H=4, d_k=16, G=2</code>: the fused width is <code>64 + 32 + 32 = 128</code>, and <code>chunk(3)</code> slices it into <code>[43, 43, 42]</code>. <strong>It does not raise.</strong> Q gets 43 instead of 64, and the failure only surfaces later at the <code>view</code>, as <code>shape &#x27;[2, 7, 4, 16]&#x27; is invalid for input of size 602</code> — a message with no connection to the actual cause.</p></div>
+<p><code>torch.chunk</code> does not raise on a non-divisible width; it just returns uneven parts (width 5 into 3 → <code>[2, 2, 1]</code>). So the rule is simple: <strong>whenever Q and K/V have different head counts, use <code>split</code> with explicit widths, never <code>chunk</code>.</strong></p>
+<pre><code class="language-python">q, k, v = qkv.split([D, G * d_k, G * d_k], dim=-1)      # explicit widths — the standard form under MQA/GQA</code></pre>
 <h2 id="4-self--cross--causal--padding">§4 Self / Cross / Causal / Padding</h2>
 <h3 id="41-self-vs-cross-attention-mandatory">4.1　Self vs Cross Attention (mandatory)</h3>
 <div class="table-wrap"><table><thead><tr><th></th><th>Self-Attention</th><th>Cross-Attention</th></tr></thead><tbody><tr><td><strong>Q source</strong></td><td>$X$</td><td>$X_\text{decoder}$ / latent / learnable queries</td></tr><tr><td><strong>K, V source</strong></td><td>$X$ (same)</td><td>$X_\text{encoder}$ / context / memory</td></tr><tr><td><strong>$L_q$ vs $L_k$</strong></td><td>equal</td><td>can differ</td></tr><tr><td><strong>Typical mask</strong></td><td>causal (decoder) or padding (encoder)</td><td>K/V-side padding mask (no causal)</td></tr><tr><td><strong>Purpose</strong></td><td>intra-position correlation</td><td>retrieve relevant info from external memory</td></tr><tr><td><strong>Examples</strong></td><td>every BERT layer; every GPT layer; ViT</td><td>Transformer Decoder's second sub-layer; DETR; Perceiver; Stable Diffusion (image Q × text K/V)</td></tr></tbody></table></div>
@@ -973,8 +996,8 @@ All checks passed.</code></pre>
 <footer class="aris-footer">
   Generated by <a href="https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep/blob/main/skills/render-html/SKILL.md">ARIS <code>/render-html</code></a> ·
   source path <code>docs/tutorials/attention_tutorial_en.md</code> ·
-  SHA256 <code>f057c218d5b6</code> ·
-  generated at 2026-07-31 02:58 UTC.
+  SHA256 <code>49459d52a2bd</code> ·
+  generated at 2026-08-24 03:10 UTC.
   This is a generated view — edit the source Markdown, then re-render.
 </footer>
 </main>

--- a/docs/tutorials/attention_tutorial_en.md
+++ b/docs/tutorials/attention_tutorial_en.md
@@ -219,6 +219,45 @@ class MultiHeadAttention(nn.Module):
         return self.W_o(self._merge(out)), w
 ```
 
+### 3.5　Fused QKV + chunk (what production code actually writes)
+
+§3.4 uses three separate `W_q / W_k / W_v`, which reads closest to the formula. For **self-attention**, the more common production form **fuses the three projections into one Linear** and then slices the output — nanoGPT, HF GPT-2 and timm's ViT all do it this way (counterexamples exist: HF LLaMA keeps separate `q_proj / k_proj / v_proj`, and cross-attention cannot fuse at all, since Q and K/V come from different inputs). The three slicings below are **element-wise identical** (`torch.equal` returns True) and differ only in readability; the GEMM saving is fused-versus-§3.4's-three-Linears.
+
+```python
+D, H, d_k = 64, 4, 16                       # D = H * d_k
+qkv_proj = nn.Linear(D, 3 * D, bias=False)  # one Linear emits Q/K/V
+qkv = qkv_proj(x)                           # [B, N, 3D]
+
+# Form 1: chunk — the most readable, hardest to get wrong on a whiteboard
+q, k, v = qkv.chunk(3, dim=-1)                          # each [B, N, D]
+q, k, v = [t.view(B, N, H, d_k).transpose(1, 2)         # → [B, H, N, d_k]
+           for t in (q, k, v)]
+
+# Form 2: nanoGPT's split — equivalent to chunk here (3D/3 = D); same view+transpose follows
+q, k, v = qkv.split(D, dim=2)
+q, k, v = [t.view(B, N, H, d_k).transpose(1, 2) for t in (q, k, v)]
+
+# Form 3: 5-D reshape + permute — timm ViT / this repo's code/mha.py
+q, k, v = qkv.reshape(B, N, 3, H, d_k).permute(2, 0, 3, 1, 4)
+```
+
+> 💡 **Why fuse** — compared with §3.4's three Linears, Q/K/V cost **one GEMM instead of three**. The FLOPs are identical; what you save is kernel launches and activation traffic, and one large matmul usually utilises the hardware better (how much depends on shapes and backend). The other reason is weight layout: HF GPT-2's `c_attn` (a `Conv1D` with weight `[D, 3D]`) concatenates Q/K/V along the output dimension in `[Q | K | V]` order, so loading pretrained weights requires matching that order (and a transpose to `[3D, D]` if you port it to `nn.Linear`).
+
+| Form | How it slices | Readability | Used by |
+| --- | --- | --- | --- |
+| Three separate Linears | no slicing | closest to the math | teaching code, §3.4 |
+| fused + `chunk(3, dim=-1)` | three equal parts | **best** | most hand-written implementations |
+| fused + `split(D, dim=2)` | parts of width D | good | nanoGPT |
+| fused + `reshape` + 5-D `permute` | one shot | poor — easy to get the axis order wrong | timm ViT, `code/mha.py` |
+
+> ⚠️ **`chunk(3)` becomes wrong the moment you use GQA (a common follow-up)** — under MQA/GQA the fused projection is no longer three equal parts but `D + 2·G·d_k` (see §6.2). Take `D=64, H=4, d_k=16, G=2`: the fused width is `64 + 32 + 32 = 128`, and `chunk(3)` slices it into `[43, 43, 42]`. **It does not raise.** Q gets 43 instead of 64, and the failure only surfaces later at the `view`, as `shape '[2, 7, 4, 16]' is invalid for input of size 602` — a message with no connection to the actual cause.
+
+`torch.chunk` does not raise on a non-divisible width; it just returns uneven parts (width 5 into 3 → `[2, 2, 1]`). So the rule is simple: **whenever Q and K/V have different head counts, use `split` with explicit widths, never `chunk`.**
+
+```python
+q, k, v = qkv.split([D, G * d_k, G * d_k], dim=-1)      # explicit widths — the standard form under MQA/GQA
+```
+
 ## §4 Self / Cross / Causal / Padding
 
 ### 4.1　Self vs Cross Attention (mandatory)

--- a/docs/tutorials/attention_tutorial_en.review.json
+++ b/docs/tutorials/attention_tutorial_en.review.json
@@ -1,7 +1,7 @@
 {
   "skill": "interview-cheatsheet (EN translation-fidelity)",
   "source": "docs/tutorials/attention_tutorial_en.md",
-  "source_sha256": "f057c218d5b6435d443d904c25e0e732705172efce84a0918a984c166a516800",
+  "source_sha256": "49459d52a2bdc516d301d1195f04ce1b0188136e1d0848c8538f8d82b2035110",
   "output": "docs/tutorials/attention_tutorial_en.html",
   "zh_source": "docs/tutorials/attention_tutorial.md",
   "reviewer": "codex gpt-5.5 xhigh, fresh thread",
@@ -33,6 +33,24 @@
         "§A appendix sanity-check transcript's exception type corrected ValueError -> AssertionError, matching mha.py's actual `assert embed_dim % num_heads == 0`; added a note that `assert` is stripped under python -O"
       ],
       "note": "Re-rendered attention_tutorial_en.html and refreshed source_sha256 (this run); gated via tools/verify_reviews.py --mode strict --reproduce."
+    }
+  ],
+  "delta_reviews": [
+    {
+      "run": "delta-2026-08-24",
+      "scope": "New §3.5 only (fused QKV: chunk / split / 5-D reshape+permute; GQA chunk(3) trap). No other content touched.",
+      "verdict": "PASS after 1 fix round",
+      "reviewer": "codex gpt-5.6-sol xhigh, fresh thread",
+      "thread_id": "01a031ba-d74f-7cb2-859e-fc75f24ec2ea",
+      "process": "Claims verified on a real PyTorch box before drafting (all three slicing forms torch.equal; GQA chunk(3) widths [43,43,42] failing later at view; chunk on width 5 -> [2,2,1]). Reviewer then re-derived all six claims and audited prose.",
+      "findings_fixed": [
+        "Form 2 (split) as printed stopped at [B,N,D] — missing the same view+transpose the chunk form gets; added, re-verified verbatim.",
+        "'differ only in GEMM count' compared the wrong pair — the three slicing forms share one GEMM; 3-to-1 is fused vs §3.4's three Linears. Reworded.",
+        "GPT-2 c_attn orientation: it is a Conv1D with weight [D,3D], Q/K/V concatenated along the OUTPUT dim — 'stacked vertically' described the transposed nn.Linear layout. Corrected, with the transpose note.",
+        "'real code almost always fuses' overstated — scoped to self-attention, with HF LLaMA (separate q/k/v_proj) and cross-attention (cannot fuse) as counterexamples.",
+        "'far better' tensor-core utilisation softened to shape/backend-dependent.",
+        "'the only correct form under MQA/GQA' narrowed to the true rule: never equal-chunk(3) unequal widths; explicit-width split is the standard form."
+      ]
     }
   ]
 }


### PR DESCRIPTION
Interviewer feedback (via the maintainer): the tutorial teaches MHA with three separate `W_q/W_k/W_v` (§3.4), but the form interviewers expect on a whiteboard is the fused `nn.Linear(D, 3D)` sliced with `.chunk(3, dim=-1)` — the idiom nanoGPT, HF GPT-2 and timm ViT actually ship.

New `§3.5` in both editions (CN canonical + EN sibling, full parity):

- **The three equivalent slicings** — `chunk(3, dim=-1)`, nanoGPT's `split(D, dim=2)`, timm's 5-D `reshape().permute()` — verified element-wise identical (`torch.equal`) on a real box before drafting.
- **Why fuse**: one GEMM vs three against §3.4's separate Linears — same FLOPs, fewer kernel launches, less activation traffic; plus the HF GPT-2 `c_attn` weight-order constraint (`Conv1D` weight `[D, 3D]`, Q|K|V concatenated along the output dim — transpose to `[3D, D]` if porting to `nn.Linear`).
- **The trap worth a section**: under MQA/GQA the fused width is `D + 2·G·d_k`, so `chunk(3)` is wrong — and it **doesn't raise**. With `D=64, G=2` it silently returns widths `[43, 43, 42]` and only fails later at the `view` with `shape '[2, 7, 4, 16]' is invalid for input of size 602` — a message unrelated to the real cause. Explicit-width `split([D, G*d_k, G*d_k])` is the standard form. Cross-linked to §6.2.

Scoped to self-attention, with HF LLaMA (separate `q/k/v_proj`) and cross-attention (cannot fuse — Q and K/V come from different inputs) as counterexamples. Question count stays at the collection-standard 25.

**Review**: gpt-5.6-sol xhigh delta review (thread `01a031ba`) re-derived all six claims; its fix round caught three real errors in the draft — the `split` form missing its `view+transpose` as printed, a GEMM comparison against the wrong baseline, and the `c_attn` orientation. Every numeric claim (`[43,43,42]`, the 602-element view error, `[2,2,1]`) reproduced in PyTorch. Both HTMLs re-rendered; `verify_reviews.py --mode strict --reproduce` PASS, delta recorded in both `.review.json` sidecars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkzGJUXJSUxdgrsjJtjAn6